### PR TITLE
adding support for scheduled posts

### DIFF
--- a/bin/parser.js
+++ b/bin/parser.js
@@ -337,6 +337,7 @@ var Parser = function() {
 		return new Promise(function(resolve, reject) {
 			var config = GLOBAL.config,
 				posts = {},
+				currentDate = new Date(),
 				curTemplate = config.template,
 				postsTemplate = fs.readFileSync('./src/templates/' + curTemplate + '/post.html'),
 				nunjucksEnv = GLOBAL.nunjucksEnv,
@@ -382,6 +383,11 @@ var Parser = function() {
 						.replace(/<!--[\s\S]*?-->/g, '');
 
 					if(metadata.published && metadata.published === 'false') {
+						return;
+					}
+
+					if (metadata.date && metadata.date > currentDate) {
+						console.log(clc.info('Skipping future post ' + metadata.filename));
 						return;
 					}
 


### PR DESCRIPTION
![jspratodolado com 2014-07-14 18-28-10 2014-07-14 18-29-13](https://cloud.githubusercontent.com/assets/23247/3577550/e356c49a-0b9d-11e4-8c55-16fe84d5180d.jpg)
This enables scheduled posts.

Posts with dates set into the future will be skipped. This way you can add posts to your src and have your blog regenerate on a cronjob or similar task runner without worrying that future posts will appear early.
