### PR TITLE
initial RSS 2.0 generation

### DIFF
--- a/bin/core.js
+++ b/bin/core.js
@@ -14,6 +14,7 @@ module.exports = {
 			.then(parser.generatePages)
 			.then(parser.getFiles)
             .then(parser.generatePosts)
+			.then(parser.generateRSS)
 			.then(parser.compileES6)
 			.then(parser.generateIndex)
 			.then(parser.generateTagsPages)

--- a/bin/resources/rss.xml
+++ b/bin/resources/rss.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ config.title }}</title>
+        <link>{{ config.domain }}</link>
+        <description>{{ config.description }}</description>
+        <managingEditor>{{ rss.author }}</managingEditor>
+        <webMaster>{{ rss.author }}</webMaster>
+        <pubDate>{{ rss.date }}</pubDate>
+        <language>{{ rss.lang }}</language>
+        <atom:link href="{{rss.link}}" rel="self" type="application/rss+xml" />
+        {% for post in posts %}
+        <item>
+            <title>{{ post.title}}</title>
+            <link>{{config.domain}}/{{post.link}}</link>
+            <description><![CDATA[{{post.content}}]]></description>
+            <pubDate>{{post.date.toUTCString()}}</pubDate>
+            <guid>{{config.domain}}/{{post.link}}</guid>
+        </item>
+        {% endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
This commit adds RSS 2.0 generation to harmonic.

It works by using a template located at `bin/resources/rss.xml`. Since this template is tied to the harmonic installation it is not affected by changes in the users templates.

RSS files are generated for all languages.

A new `harmonic.json` key is used if present: `author_email`. The RSS 2.0 spec requires/recommend that the managingEditor and webMaster channel entries should be emails. If this entry is present in the configuration file then it is used along with the `author` entry to generate something similar to **contato@andregarzia.com (Andre Garzia)** which is the preferred format described in the spec. If it is not present then just the author name is used. I doubt any feed reader will reject a feed because the those fields are not email.
