### PR TITLE
Use rimraf instead of `rm -rf`

### DIFF
--- a/bin/parser.js
+++ b/bin/parser.js
@@ -126,16 +126,19 @@ var Parser = function() {
 		});
 	};
 
-	this.clean = function() {
-		return new Promise(function (resolve, reject) {
-			var exec = require('child_process').exec,
-				child = null;
-			child = exec('rm -rf ./public',function(err,out) {
-			 	console.log(clc.warn('Cleaning up...'));
-			 	resolve();
-			});
-		});
-	};
+    this.clean = function() {
+        return new Promise(function (resolve, reject) {
+            var rimfaf = require('rimraf');
+            rimfaf('./public', function(err) {
+                if (err) {
+                    reject(err);
+                } else {
+                    console.log(clc.warn('Cleaning up...'));
+                    resolve();
+                }
+            });
+        });
+    };
 
 	this.createPublicFolder = function(argument) {
 		return new Promise(function(resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "nunjucks": "^1.0.4",
         "permalinks": "^0.2.1",
         "promise": "^5.0.0",
+        "rimraf": "^2.2.8",
         "traceur": "0.0.49",
         "underscore": "^1.6.0",
         "v8-argv": "^0.2.0",


### PR DESCRIPTION
Fixes Windows incompatibility and adds error handling to the Parser#clean task.

This fixes the issue [reported here](https://github.com/es6rocks/harmonic/issues/32#issuecomment-49119091).
