### PR TITLE
Workaround node-static's Windows path resolution bug, add error handling, fixes #32

### DIFF
--- a/bin/cli/util.js
+++ b/bin/cli/util.js
@@ -145,11 +145,17 @@ module.exports = {
 
     run: function(port) {
         var clc = helpers.cliColor(),
-            file = new staticServer.Server('./public');
+            file = new staticServer.Server(path.join(process.cwd(), 'public'));
         console.log(clc.info('Harmonic site is running on http://localhost:' + port));
         require('http').createServer(function(request, response) {
                 request.addListener('end', function() {
-                        file.serve(request, response);
+                        file.serve(request, response, function (err) {
+                            if (err) {
+                                console.log(clc.error("Error serving " + request.url + " - " + err.message));
+                                response.writeHead(err.status, err.headers);
+                                response.end();
+                            }
+                        });
                     }).resume();
             }).listen(port);
     }


### PR DESCRIPTION
Looks like `node-static` has issues resolving relative paths in Windows. I've added error handling in this PR which clearly demonstrates the issue.

The current node-static stable release (0.7.3) does not resolve the relative path `./public` properly in Windows, hence the 403. ([screenshot](http://i.imgur.com/hYwNRFX.png))

Passing an absolute path avoids this issue.

p.s.: I've also tried updating to node-static's latest commit (https://github.com/cloudhead/node-static/commit/beb25d33ed7070142ca567896663e3ef7ba68787), however the relative paths are even more broken. It seems to duplicate the path, independent of using a relative or absolute path ([screenshot](http://i.imgur.com/H1t0yzY.png)). Hopefully this bug does not land on their next release, I'll try to analyse the issue on their repo and report it later.

Obligatory: Harmonic running on Windows from the native command prompt `;)`
![Harmonic running on Windows from the native command prompt](http://i.imgur.com/WwtsyAW.png)

fixes #32 (fo' real this time!)
