### PR TITLE
Remove sync calls

### DIFF
--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -23,7 +23,7 @@ async function build(passedPath) {
     const postsMetadata = await harmonic.generatePosts(harmonic.getPostFiles());
 
     harmonic.generateRSS(postsMetadata, pagesMetadata);
-    harmonic.compileJS(postsMetadata, pagesMetadata);
+    await harmonic.compileJS(postsMetadata, pagesMetadata);
     harmonic.generateIndex(postsMetadata, pagesMetadata);
     harmonic.generateTagsPages(postsMetadata);
 

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -19,7 +19,7 @@ async function build(passedPath) {
 
     await harmonic.compileCSS();
 
-    const pagesMetadata = await harmonic.generatePages(harmonic.getPageFiles());
+    const pagesMetadata = await harmonic.generatePages(await harmonic.getPageFiles());
     const postsMetadata = await harmonic.generatePosts(await harmonic.getPostFiles());
 
     await harmonic.generateRSS(postsMetadata, pagesMetadata);

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -22,7 +22,7 @@ async function build(passedPath) {
     const pagesMetadata = await harmonic.generatePages(harmonic.getPageFiles());
     const postsMetadata = await harmonic.generatePosts(harmonic.getPostFiles());
 
-    harmonic.generateRSS(postsMetadata, pagesMetadata);
+    await harmonic.generateRSS(postsMetadata, pagesMetadata);
     await harmonic.compileJS(postsMetadata, pagesMetadata);
     harmonic.generateIndex(postsMetadata, pagesMetadata);
     harmonic.generateTagsPages(postsMetadata);

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -15,7 +15,7 @@ async function build(passedPath) {
 
     harmonic.start(); // useless, remove?
     harmonic.clean();
-    harmonic.createPublicFolder();
+    await harmonic.createPublicFolder();
 
     await harmonic.compileCSS();
 

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -20,7 +20,7 @@ async function build(passedPath) {
     await harmonic.compileCSS();
 
     const pagesMetadata = await harmonic.generatePages(harmonic.getPageFiles());
-    const postsMetadata = await harmonic.generatePosts(harmonic.getPostFiles());
+    const postsMetadata = await harmonic.generatePosts(await harmonic.getPostFiles());
 
     await harmonic.generateRSS(postsMetadata, pagesMetadata);
     await harmonic.compileJS(postsMetadata, pagesMetadata);

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -14,7 +14,7 @@ async function build(passedPath) {
     const harmonic = new Harmonic(sitePath, { quiet: false });
 
     harmonic.start(); // useless, remove?
-    harmonic.clean();
+    await harmonic.clean();
     await harmonic.createPublicFolder();
 
     await harmonic.compileCSS();

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -125,14 +125,14 @@ export default class Harmonic {
         await compiler[currentCSSCompiler]();
     }
 
-    compileJS(postsMetadata, pagesMetadata) {
-        const harmonicClient = fs.readFileSync(`${rootdir}/bin/client/harmonic-client.js`)
-            .toString()
-            .replace(/__HARMONIC\.POSTS__/g, JSON.stringify(Helper.sortPosts(postsMetadata)))
-            .replace(/__HARMONIC\.PAGES__/g, JSON.stringify(pagesMetadata))
-            .replace(/__HARMONIC\.CONFIG__/g, JSON.stringify(this.config));
+    async compileJS(postsMetadata, pagesMetadata) {
+        let harmonicClient = await fs.readFileAsync(`${rootdir}/bin/client/harmonic-client.js`);
+        harmonicClient = harmonicClient.toString()
+        .replace(/__HARMONIC\.POSTS__/g, JSON.stringify(Helper.sortPosts(postsMetadata)))
+        .replace(/__HARMONIC\.PAGES__/g, JSON.stringify(pagesMetadata))
+        .replace(/__HARMONIC\.CONFIG__/g, JSON.stringify(this.config));
 
-        fs.writeFileSync(path.join(this.sitePath, 'public/harmonic.js'), harmonicClient);
+        await fs.writeFileSync(path.join(this.sitePath, 'public/harmonic.js'), harmonicClient);
     }
 
     generateTagsPages(postsMetadata) {

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -73,9 +73,9 @@ export default class Harmonic {
         rimrafSync(path.join(this.sitePath, 'public'), { maxBusyTries: 20 });
     }
 
-    createPublicFolder() {
+    async createPublicFolder() {
         let publicDirPath = path.join(this.sitePath, 'public');
-        mkdirp.sync(publicDirPath);
+        await mkdirpAsync(publicDirPath);
         console.log(clc.info('Successfully generated public folder'));
     }
 

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -132,7 +132,7 @@ export default class Harmonic {
         .replace(/__HARMONIC\.PAGES__/g, JSON.stringify(pagesMetadata))
         .replace(/__HARMONIC\.CONFIG__/g, JSON.stringify(this.config));
 
-        await fs.writeFileSync(path.join(this.sitePath, 'public/harmonic.js'), harmonicClient);
+        await fs.writeFileAsync(path.join(this.sitePath, 'public/harmonic.js'), harmonicClient);
     }
 
     generateTagsPages(postsMetadata) {

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -439,12 +439,12 @@ export default class Harmonic {
         return pages;
     }
 
-    getPostFiles() {
+    async getPostFiles() {
         const files = {};
 
         for (const lang of this.config.i18n.languages) {
-            files[lang] = fs.readdirSync(path.join(this.sitePath, postspath, lang))
-                .filter((p) => rMarkdownExt.test(p));
+            files[lang] = await fs.readdirAsync(path.join(this.sitePath, postspath, lang));
+            files[lang] = files[lang].filter((p) => rMarkdownExt.test(p));
         }
 
         return files;

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -450,13 +450,13 @@ export default class Harmonic {
         return files;
     }
 
-    getPageFiles() {
+    async getPageFiles() {
         const files = {};
 
         for (const lang of this.config.i18n.languages) {
             const langPath = path.join(this.sitePath, pagespath, lang);
-            mkdirp.sync(langPath);
-            files[lang] = fs.readdirSync(langPath).filter((p) => rMarkdownExt.test(p));
+            await mkdirpAsync(langPath);
+            files[lang] = await fs.readdirAsync(langPath).filter((p) => rMarkdownExt.test(p));
         }
 
         return files;

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -6,7 +6,7 @@ import permalinks from 'permalinks';
 import MkMeta from 'marked-metadata';
 import mkdirp from 'mkdirp';
 import { ncp } from 'ncp';
-import { sync as rimrafSync } from 'rimraf';
+import rimraf from 'rimraf';
 import stylus from 'stylus';
 import less from 'less';
 import { rootdir, postspath, pagespath } from './config';
@@ -15,6 +15,7 @@ import Theme from './theme';
 promisifyAll(fs);
 const mkdirpAsync = promisify(mkdirp);
 const ncpAsync = promisify(ncp);
+const rimrafAsync = promisify(rimraf);
 
 const clc = cliColor();
 const rMarkdownExt = /\.(?:md|markdown)$/;
@@ -68,9 +69,9 @@ export default class Harmonic {
         return Promise.resolve();
     }
 
-    clean() {
+    async clean() {
         console.log(clc.warn('Cleaning up...'));
-        rimrafSync(path.join(this.sitePath, 'public'), { maxBusyTries: 20 });
+        await rimrafAsync(path.join(this.sitePath, 'public'), { maxBusyTries: 20 });
     }
 
     async createPublicFolder() {

--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -462,10 +462,10 @@ export default class Harmonic {
         return files;
     }
 
-    generateRSS(postsMetadata, pagesMetadata) {
+    async generateRSS(postsMetadata, pagesMetadata) {
         var _posts = null,
             nunjucksEnv = this.nunjucksEnv,
-            rssTemplate = fs.readFileSync(`${__dirname}/resources/rss.xml`),
+            rssTemplate = await fs.readFileAsync(`${__dirname}/resources/rss.xml`),
             rssTemplateNJ = nunjucks.compile(rssTemplate.toString(), nunjucksEnv),
             rssContent = '',
             rssPath = null,
@@ -504,8 +504,8 @@ export default class Harmonic {
                 pages: pagesMetadata
             });
 
-            mkdirp.sync(rssPath);
-            fs.writeFileSync(`${rssPath}/rss.xml`, rssContent);
+            await mkdirpAsync(rssPath);
+            await fs.writeFileAsync(`${rssPath}/rss.xml`, rssContent);
             console.log(clc.info(`${lang}/rss.xml file successfully created`));
         }
     }

--- a/src/bin/theme.js
+++ b/src/bin/theme.js
@@ -1,5 +1,5 @@
 import { resolve, join } from 'path';
-import { readFileSync, statSync } from 'fs';
+import { readFileSync } from 'fs';
 import dd from 'dedent';
 
 export default class Theme {


### PR DESCRIPTION
Attempt to fix #150   
There's still some sync calls we need to remove:
`readFileSync()` in `src/bin/theme.js`
The `getFileContents()` method is being called a lot of times in Harmonic class, and i can't find a way to make it async.

`readFileSync()` in `src/bin/helpers.js`
We're calling `readFileSync` in `helpers.js` file, but consuming it on the constructor (see next).

`existsSync()` in `src/bin/parser.js`
Kinda complicated because we're calling `existsSync()` method inside the `constructor` and we can't make a `constructor` async.
I tried with an async IIFE inside the `constructor` and it not worked well.
Also, the method `getConfig()` is called inside the constructor.

Travis says it's ok so far.
https://travis-ci.org/JSRocksHQ/harmonic/builds/61412823

//cc @UltCombo 