### PR TITLE
Parallelize build

### DIFF
--- a/src/bin/parser.js
+++ b/src/bin/parser.js
@@ -118,7 +118,7 @@ export default class Harmonic {
         await fs.writeFileAsync(path.join(this.sitePath, 'public/harmonic.js'), harmonicClient);
     }
 
-    generateTagsPages(postsMetadata) {
+    async generateTagsPages(postsMetadata) {
         var postsByTag = {},
             nunjucksEnv = this.nunjucksEnv,
             tagTemplate = this.theme.getFileContents('index.html'),
@@ -137,11 +137,8 @@ export default class Harmonic {
                     .split(' ')
                     .join('-');
 
-                    if (Array.isArray(postsByTag[tag])) {
-                        postsByTag[tag].push(postsMetadata[lang][i]);
-                    } else {
-                        postsByTag[tag] = [postsMetadata[lang][i]];
-                    }
+                    postsByTag[tag] = postsByTag[tag] || [];
+                    postsByTag[tag].push(postsMetadata[lang][i]);
                 }
             }
 
@@ -159,8 +156,8 @@ export default class Harmonic {
                     tagPath = path.join(this.sitePath, 'public/categories', lang, i);
                 }
 
-                mkdirp.sync(tagPath);
-                fs.writeFileSync(path.join(tagPath, 'index.html'), tagContent);
+                await mkdirpAsync(tagPath);
+                await fs.writeFileAsync(path.join(tagPath, 'index.html'), tagContent);
                 console.log(
                     clc.info(`Successfully generated tag[${i}] archive html file`)
                 );
@@ -168,7 +165,7 @@ export default class Harmonic {
         }
     }
 
-    generateIndex(postsMetadata, pagesMetadata) {
+    async generateIndex(postsMetadata, pagesMetadata) {
         var lang,
             _posts = null,
             nunjucksEnv = this.nunjucksEnv,
@@ -194,8 +191,8 @@ export default class Harmonic {
             } else {
                 indexPath = path.join(this.sitePath, 'public', lang);
             }
-            mkdirp.sync(indexPath);
-            fs.writeFileSync(path.join(indexPath, 'index.html'), indexContent);
+            await mkdirpAsync(indexPath);
+            await fs.writeFileAsync(path.join(indexPath, 'index.html'), indexContent);
             console.log(clc.info(`${lang}/index file successfully created`));
         }
     }


### PR DESCRIPTION
Testing on my machine, this branch is up to 10% faster than master when building the JS Rocks website.
@jaydson please test.

The next step (in a future PR) would be to parallelize `harmonic.clean` and the in-memory generation of the file contents, and then output the resulting files right after `clean` finishes.
I'm leaving this for the future as it may require splitting the CSS preprocessing and posts/pages/index/categories generation in two functions each, or some smarter trickery in order to achieve this parallelism.