### PR TITLE
Update to Babel 6; Change named exports style to workaround Babel bug T7048

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,7 +7,14 @@ module.exports = {
     },
     distBase: 'dist/',
     config: {
-        babel: { optional: ['runtime'], stage: 0 },
+        babel: {
+            presets: ['es2015'],
+            plugins: [
+                'syntax-async-functions', 'transform-async-to-generator',
+                'syntax-function-bind', 'transform-function-bind',
+                'transform-runtime'
+            ]
+        },
         mocha: '--colors --bail --timeout 15000'
     }
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ES2016"
   ],
   "dependencies": {
-    "babel-runtime": "5.8.34",
+    "babel-runtime": "6.3.19",
     "bluebird": "^3.1.1",
     "browser-sync": "^2.11.0",
     "chokidar": "^1.4.2",
@@ -60,10 +60,16 @@
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0-beta6",
+    "babel-plugin-syntax-async-functions": "^6.3.13",
+    "babel-plugin-syntax-function-bind": "^6.3.13",
+    "babel-plugin-transform-async-to-generator": "^6.4.6",
+    "babel-plugin-transform-function-bind": "^6.3.13",
+    "babel-plugin-transform-runtime": "^6.4.3",
+    "babel-preset-es2015": "^6.3.13",
     "chalk": "^1.1.1",
     "glob-manipulate": "^1.1.1",
     "gulp": "^3.9.0",
-    "gulp-babel": "^5.3.0",
+    "gulp-babel": "^6.1.1",
     "gulp-eslint": "^1.1.1",
     "gulp-filter": "^3.0.1",
     "gulp-load-plugins": "^1.2.0",
@@ -84,7 +90,7 @@
   "scripts": {
     "dev": "gulp",
     "test": "gulp build",
-    "update-babel": "npm install --save --save-exact babel-runtime@5 && npm update --depth=1 babel-core",
+    "update-babel": "npm install --save --save-exact babel-runtime@6 && npm update --depth=1 babel-core",
     "require-clean-work-tree": "(git update-index -q --ignore-submodules --refresh && git diff-files --quiet --ignore-submodules && git diff-index --cached --quiet --ignore-submodules HEAD --) || (echo You have uncommitted changes. Please commit or stash them. >&2 && exit 1)",
     "preversion": "git pull && npm run --silent require-clean-work-tree && npm run --silent update-babel && (git diff-files --quiet -- package.json || git commit -m \"update Babel\" -- package.json) && npm test",
     "postversion": "git push --follow-tags && npm publish"

--- a/src/bin/cli/util.js
+++ b/src/bin/cli/util.js
@@ -19,10 +19,9 @@ const mkdirpAsync = promisify(mkdirp);
 const ncpAsync = promisify(ncp);
 const clc = cliColor();
 
-export { init, config, newFile, run, openFile };
 
 // Open a file using browser, text-editor
-function openFile(type, sitePath, file) {
+export function openFile(type, sitePath, file) {
     if (type === 'file') {
         open(path.resolve(sitePath, file));
     } else {
@@ -31,7 +30,7 @@ function openFile(type, sitePath, file) {
     }
 }
 
-function config(passedPath, _skipFindRoot = false) {
+export function config(passedPath, _skipFindRoot = false) {
     const sitePath = _skipFindRoot ? passedPath : findHarmonicRoot(passedPath);
 
     if (!sitePath) {
@@ -107,7 +106,7 @@ function config(passedPath, _skipFindRoot = false) {
     });
 }
 
-async function init(sitePath) {
+export async function init(sitePath) {
     const skeletonPath = path.join(rootdir, 'bin/skeleton');
 
     await mkdirpAsync(sitePath);
@@ -137,7 +136,7 @@ async function init(sitePath) {
  * @param {string} type - The new file's type. Can be either 'post' or 'page'.
  * @param {string} title - The new file's title.
  */
-function newFile(passedPath, type, title, autoOpen) {
+export function newFile(passedPath, type, title, autoOpen) {
     const sitePath = findHarmonicRoot(passedPath);
 
     if (!sitePath) {
@@ -177,7 +176,7 @@ function newFile(passedPath, type, title, autoOpen) {
     ));
 }
 
-async function run(passedPath, port, autoOpen) {
+export async function run(passedPath, port, autoOpen) {
     const sitePath = findHarmonicRoot(passedPath);
 
     if (!sitePath) {

--- a/src/bin/client/.babelrc
+++ b/src/bin/client/.babelrc
@@ -1,3 +1,4 @@
 {
-  "blacklist": ["runtime"]
+    // Remove the `transform-runtime` plugin.
+    "plugins": []
 }

--- a/src/bin/core.js
+++ b/src/bin/core.js
@@ -4,9 +4,7 @@ import Harmonic from './parser';
 import { cliColor } from './helpers';
 const clc = cliColor();
 
-export { build };
-
-async function build(passedPath) {
+export async function build(passedPath) {
     const startTime = Date.now();
 
     const sitePath = findHarmonicRoot(passedPath);

--- a/src/bin/helpers.js
+++ b/src/bin/helpers.js
@@ -3,11 +3,8 @@ import { join, resolve, extname, basename } from 'path';
 import strIncludes from 'core-js/library/fn/string/virtual/includes';
 import _cliColor from 'cli-color';
 
-export { cliColor, isHarmonicProject, getConfig, titleToFilename,
-    findHarmonicRoot, displayNonInitializedFolderErrorMessage, getFileName, getStructure };
-
 // CLI color
-function cliColor() {
+export function cliColor() {
     return {
         info: _cliColor.green,
         error: _cliColor.red,
@@ -17,7 +14,7 @@ function cliColor() {
 }
 
 // Friendly message for non-initialized folder
-function displayNonInitializedFolderErrorMessage() {
+export function displayNonInitializedFolderErrorMessage() {
     const clc = cliColor();
 
     console.log(
@@ -29,7 +26,7 @@ function displayNonInitializedFolderErrorMessage() {
 }
 
 // Check if harmonic.json file exists
-function isHarmonicProject(sitePath) {
+export function isHarmonicProject(sitePath) {
     try {
         getConfig(sitePath);
         return true;
@@ -39,7 +36,7 @@ function isHarmonicProject(sitePath) {
 }
 
 // Find harmonic.json. Returns path or false.
-function findHarmonicRoot(sitePath) {
+export function findHarmonicRoot(sitePath) {
     let currentPath = resolve(sitePath);
     let oldPath = '';
 
@@ -57,21 +54,21 @@ function findHarmonicRoot(sitePath) {
     return currentPath;
 }
 
-function getConfig(sitePath) {
+export function getConfig(sitePath) {
     return JSON.parse(readFileSync(join(sitePath, 'harmonic.json')).toString());
 }
 
-function titleToFilename(title) {
+export function titleToFilename(title) {
     return title.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase() + '.md';
 }
 
-function getFileName(file) {
+export function getFileName(file) {
     const filename = basename(file, extname(file));
     const checkDate = new Date(filename.substr(0, 10));
     return isNaN(checkDate.getDate()) ? filename : filename.substr(11, filename.length);
 }
 
-function getStructure(defaultLang, lang, permaLink) {
+export function getStructure(defaultLang, lang, permaLink) {
     // If is the default language, generate in the root path
     if (defaultLang === lang && permaLink::strIncludes(':language')) {
         // TODO allow customizing the permalink format? https://github.com/JSRocksHQ/harmonic/pull/97#issuecomment-67596545


### PR DESCRIPTION
Babel currently has a bug concerning exporting/hoisting async function declarations: https://phabricator.babeljs.io/T7048
I've changed the remaining named exports' style as well for consistency.

Needs review/testing.
